### PR TITLE
ATLへの移行と認証処理の改善

### DIFF
--- a/AlbumArt.cs
+++ b/AlbumArt.cs
@@ -2,8 +2,8 @@
 using Newtonsoft.Json.Linq;
 using SpotifyAPI.Web;
 using System.Text.RegularExpressions;
-using TagLib;
 using musicDL.Resources;
+using ATL;
 
 namespace musicDL
 {
@@ -11,7 +11,7 @@ namespace musicDL
     {
         public static async Task SelectMetadata(string artist, string title, string filePath, Dictionary<string, object> setting)
         {
-            TagLib.File musicFile = TagLib.File.Create(filePath);
+            var track = new Track(filePath);
 
             string clientId = setting["spotifyClientId"].ToString() ??
                 throw new ArgumentNullException("spotifyClientId");
@@ -74,8 +74,8 @@ namespace musicDL
                     select = new MusicInfo(info.Name, info.Artists.Select(x => x.Name).ToArray(),
                         info.Album.Name, info.Album.Artists.Select(x => x.Name).ToArray(),
                         new Uri(info.Album.Images[0].Url), info.Album.ReleaseDate, info.ExternalIds["isrc"],
-                        Convert.ToUInt32(info.DiscNumber), Convert.ToUInt32(info.TrackNumber),
-                        Convert.ToUInt32(info.Album.TotalTracks));
+                        info.DiscNumber, info.TrackNumber,
+                        info.Album.TotalTracks);
                 }
                 catch (AggregateException ex)
                 {
@@ -118,7 +118,7 @@ namespace musicDL
                     st.Close();
                     Console.WriteLine($@"Album Art on {albumArtPath}");
                 }
-                else if (System.IO.File.Exists(albumArt))
+                else if (File.Exists(albumArt))
                 {
                     albumArtPath = albumArt;
                 }
@@ -128,10 +128,9 @@ namespace musicDL
                     return;
                 }
                 //Apply Album Art
-                ByteVector bv = new(await System.IO.File.ReadAllBytesAsync(albumArtPath));
-                IPicture picture = new Picture(bv);
-                musicFile.Tag.Pictures = new IPicture[] { picture };
-                //Console.WriteLine($"Album Art: {imageUrl}");
+                track.EmbeddedPictures.Clear();
+                var albumArtInfo = PictureInfo.fromBinaryData(File.ReadAllBytes(albumArtPath));
+                track.EmbeddedPictures.Add(albumArtInfo);
             }
             catch (Exception ex)
             {
@@ -140,81 +139,26 @@ namespace musicDL
             }
             #endregion
 
-            #region add artist information
+            //Add Metadata
             try
             {
-                musicFile.Tag.Performers = select.Artists;
+                var release = DateTime.Parse(select.Release);
+                track.Title = select.Title;
+                track.Album = select.Album;
+                track.AlbumArtist = string.Join(' ', select.AlbumArtists);
+                track.Artist = string.Join(' ', select.Artists);
+                track.Year = release.Year;
+                track.OriginalReleaseDate = release;
+                track.DiscNumber = select.DiskNum;
+                track.TrackNumber = select.TrackNum;
+                track.ISRC = select.ISRC;
+                track.Save();
             }
-            catch { }
-            #endregion
-
-            #region Add music title
-            try
+            catch (Exception ex)
             {
-                musicFile.Tag.Title = select.Title;
+                Console.WriteLine($@"Metadata: {ex.Message}");
+                Console.WriteLine(ex);
             }
-            catch { }
-            #endregion
-
-            #region add album info
-            try
-            {
-                musicFile.Tag.Album = select.Album;
-            }
-            catch { }
-            #endregion
-
-            #region add album artists
-            try
-            {
-                musicFile.Tag.AlbumArtists = select.AlbumArtists;
-            }
-            catch { }
-            #endregion
-
-            #region add id
-            try
-            {
-                musicFile.Tag.ISRC = select.ISRC;
-            }
-            catch { }
-            #endregion
-
-            #region add disk num
-            try
-            {
-                musicFile.Tag.DiscCount = select.DiskNum;
-            }
-            catch { }
-            #endregion
-
-            #region add track num
-            try
-            {
-                musicFile.Tag.Track = select.TrackNum;
-            }
-            catch { }
-            #endregion
-
-            #region add release
-            try
-            {
-                var release = select.Release;
-                if (DateTime.TryParse(release, out var date))
-                {
-                    musicFile.Tag.Year = Convert.ToUInt32(date.Year);
-                }
-            }
-            catch { }
-            #endregion
-
-            #region add album track num
-            try
-            {
-                musicFile.Tag.TrackCount = select.TrackNum;
-            }
-            catch { }
-            #endregion
             return;
         }
 
@@ -237,9 +181,9 @@ namespace musicDL
                     var isrc = items[i].ExternalIds["isrc"]?.ToString() ?? throw new Exception();
                     var diskNum = items[i].DiscNumber;
                     var trackNum = items[i].TrackNumber;
-                    var albumTrackNum = items?[i].Album.TotalTracks;
+                    var albumTrackNum = items[i].Album.TotalTracks;
                     MusicInfo musicInfo = new(title, (from artist in items?[i]?.Artists ?? throw new Exception() select artist.Name ?? throw new Exception()).ToArray(), album, (from artist in items[i].Album.Artists ?? throw new Exception() select artist.Name ?? throw new Exception()).ToArray(), new Uri(albumArt),
-                        release, isrc, Convert.ToUInt32(diskNum), Convert.ToUInt32(trackNum), Convert.ToUInt32(albumTrackNum));
+                        release, isrc, diskNum, trackNum, albumTrackNum);
                     list.Add(musicInfo);
                 }
                 n += 3;
@@ -303,8 +247,8 @@ namespace musicDL
                         MusicInfo musicInfo = new(info.Name, info.Artists.Select(x => x.Name).ToArray(),
                             info.Album.Name, info.Album.Artists.Select(x => x.Name).ToArray(),
                             new Uri(info.Album.Images[0].Url), info.Album.ReleaseDate,info.ExternalIds["isrc"],
-                            Convert.ToUInt32(info.DiscNumber), Convert.ToUInt32(info.TrackNumber),
-                            Convert.ToUInt32(info.Album.TotalTracks));
+                            info.DiscNumber, info.TrackNumber,
+                            info.Album.TotalTracks);
                         return musicInfo;
 
                     }
@@ -343,13 +287,14 @@ namespace musicDL
             public Uri AlbumArt { get; set; }
             public string Release { get; set; }
             public string ISRC { get; set; }
-            public uint DiskNum { get; set; }
-            public uint TrackNum { get; set; }
-            public uint AlbumTrackNum { get; set; }
+            public int DiskNum { get; set; }
+            public int TrackNum { get; set; }
+            public int AlbumTrackNum { get; set; }
 
 
-            public MusicInfo(string title, string[] artists, string album, string[] albumArtists,
-                Uri albumArt, string release, string isrc, uint diskNum, uint trackNum, uint albumTrackNum)
+            public MusicInfo(string title, string[] artists, string album,
+                string[] albumArtists, Uri albumArt, string release,
+                string isrc, int diskNum, int trackNum, int albumTrackNum)
             {
                 Title = title;
                 Artists = artists;
@@ -362,19 +307,20 @@ namespace musicDL
                 TrackNum = trackNum;
                 AlbumTrackNum = albumTrackNum;
             }
+
             public MusicInfo()
             {
-                Title = string.Empty;
+                Title = "";
                 Artists = [];
-                Album = string.Empty;
+                Album = "";
                 AlbumArtists = [];
-                AlbumArt = new Uri("https://shuit.net");
-                Release = string.Empty;
-                ISRC = string.Empty;
+                AlbumArt = new Uri("https://example.com");
+                Release = "";
+                ISRC = "";
                 DiskNum = 0;
                 TrackNum = 0;
                 AlbumTrackNum = 0;
             }
-        }
+            }
     }
 }

--- a/AudioConverter.cs
+++ b/AudioConverter.cs
@@ -1,3 +1,4 @@
+using ATL;
 using System.Diagnostics;
 
 namespace musicDL
@@ -47,7 +48,7 @@ namespace musicDL
 
             // FFmpegコマンドの構築
             string ffmpegArgs = BuildFFmpegArgs(inputPath, outputPath, targetFormat);
-            
+
             if (IsDebug)
                 Console.WriteLine($"ffmpeg {ffmpegArgs}");
 
@@ -57,12 +58,12 @@ namespace musicDL
                 Arguments = ffmpegArgs,
                 UseShellExecute = IsDebug,
                 CreateNoWindow = !IsDebug,
-                RedirectStandardOutput = !IsDebug,
-                RedirectStandardError = !IsDebug
+                RedirectStandardOutput = false,
+                RedirectStandardError = false
             };
 
             using Process? process = Process.Start(startInfo);
-            if (process == null) 
+            if (process == null)
                 throw new Exception("FFmpegプロセスの開始に失敗しました");
 
             while (!process.HasExited)
@@ -114,7 +115,7 @@ namespace musicDL
         public async Task<string> ConvertWithMetadataCopyAsync(string inputPath, AudioExtension targetFormat, string outputPath = "")
         {
             string convertedPath = await ConvertAudioAsync(inputPath, targetFormat, outputPath);
-            
+
             // メタデータをコピー
             try
             {
@@ -131,31 +132,11 @@ namespace musicDL
             return convertedPath;
         }
 
-        private async Task CopyMetadataAsync(string sourcePath, string targetPath)
+        private static async Task CopyMetadataAsync(string sourcePath, string targetPath)
         {
-            // TagLibSharpを使用してメタデータをコピー
-            using var sourceFile = TagLib.File.Create(sourcePath);
-            using var targetFile = TagLib.File.Create(targetPath);
-
-            targetFile.Tag.Title = sourceFile.Tag.Title;
-            targetFile.Tag.Artists = sourceFile.Tag.Artists;
-            targetFile.Tag.Album = sourceFile.Tag.Album;
-            targetFile.Tag.AlbumArtists = sourceFile.Tag.AlbumArtists;
-            targetFile.Tag.Genres = sourceFile.Tag.Genres;
-            targetFile.Tag.Year = sourceFile.Tag.Year;
-            targetFile.Tag.Track = sourceFile.Tag.Track;
-            targetFile.Tag.TrackCount = sourceFile.Tag.TrackCount;
-            targetFile.Tag.Disc = sourceFile.Tag.Disc;
-            targetFile.Tag.DiscCount = sourceFile.Tag.DiscCount;
-            targetFile.Tag.Comment = sourceFile.Tag.Comment;
-
-            // アルバムアートをコピー
-            if (sourceFile.Tag.Pictures.Length > 0)
-            {
-                targetFile.Tag.Pictures = sourceFile.Tag.Pictures;
-            }
-
-            targetFile.Save();
+            var sourceTrack = new Track(sourcePath);
+            var targetTrack = new Track(targetPath);
+            sourceTrack.CopyMetadataTo(targetTrack);
             await Task.CompletedTask;
         }
     }

--- a/SharingMusic.cs
+++ b/SharingMusic.cs
@@ -102,15 +102,45 @@ namespace musicDL
                 httpListener.Stop();
                 throw new UserInputSkipException();
             }
+            Console.WriteLine(); // Uploading... とぶつかるので改行
             var context = await contextTask;
             var query = context.Request.Url?.Query;
 
             // レスポンスを送信
-            var responseString = "<html><body><h1>認証完了</h1><p>このタブを閉じてアプリケーションに戻ってください。</p></body></html>";
-            var buffer = Encoding.UTF8.GetBytes(responseString);
-            context.Response.ContentLength64 = buffer.Length;
-            await context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
-            context.Response.OutputStream.Close();
+            try
+            {
+                var responseString = await LoadAuthSuccessHtml();
+                var buffer = Encoding.UTF8.GetBytes(responseString);
+                
+                context.Response.StatusCode = 200;
+                context.Response.ContentType = "text/html; charset=utf-8";
+                context.Response.ContentLength64 = buffer.Length;
+                
+                using (var output = context.Response.OutputStream)
+                {
+                    output.Write(buffer, 0, buffer.Length);
+                    output.Flush();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Response error: {ex.Message}");
+                try
+                {
+                    var errorResponse = "Authentication completed. You can close this tab.";
+                    var errorBuffer = Encoding.UTF8.GetBytes(errorResponse);
+                    context.Response.StatusCode = 200;
+                    context.Response.ContentType = "text/plain; charset=utf-8";
+                    context.Response.ContentLength64 = errorBuffer.Length;
+                    using (var output = context.Response.OutputStream)
+                    {
+                        output.Write(errorBuffer, 0, errorBuffer.Length);
+                        output.Flush();
+                    }
+                }
+                catch { }
+            }
+            context.Response.Close();
             httpListener.Stop();
 
             // 認証コードを取得
@@ -202,6 +232,44 @@ namespace musicDL
                 throw new InvalidOperationException("Access token not found in response");
 
             return tokenData["access_token"].ToString()!;
+        }
+
+        private static async Task<string> LoadAuthSuccessHtml()
+        {
+            try
+            {
+                var htmlFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "auth-success.html");
+                if (File.Exists(htmlFilePath))
+                {
+                    return await File.ReadAllTextAsync(htmlFilePath);
+                }
+                
+                // フォールバック: ファイルが見つからない場合は基本的なHTMLを返す
+                return @"<!DOCTYPE html>
+<html lang=""ja"">
+<head>
+    <meta charset=""UTF-8"">
+    <title>認証完了</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; margin-top: 100px; background-color: #f0f0f0; }
+        .container { background: white; padding: 50px; border-radius: 10px; box-shadow: 0 4px 8px rgba(0,0,0,0.1); display: inline-block; }
+        h1 { color: #4CAF50; margin-bottom: 20px; }
+        p { color: #333; font-size: 18px; }
+    </style>
+</head>
+<body>
+    <div class=""container"">
+        <h1>✓ 認証完了！</h1>
+        <p>このタブを閉じてアプリケーションに戻ってください。</p>
+    </div>
+</body>
+</html>";
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"HTML file loading error: {ex.Message}");
+                return "<html><body><h1>Success!</h1><p>このタブを閉じてアプリケーションに戻ってください。</p></body></html>";
+            }
         }
 
         private static Dictionary<string, string> ParseQueryString(string query)

--- a/auth-success.html
+++ b/auth-success.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>認証完了 - musicDL</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #333;
+        }
+        
+        .container {
+            background: white;
+            padding: 3rem;
+            border-radius: 20px;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            max-width: 500px;
+            width: 90%;
+        }
+        
+        .success-icon {
+            width: 80px;
+            height: 80px;
+            background: #4CAF50;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto 2rem;
+            animation: pulse 2s infinite;
+        }
+        
+        .success-icon::after {
+            content: '✓';
+            color: white;
+            font-size: 2.5rem;
+            font-weight: bold;
+        }
+        
+        @keyframes pulse {
+            0% { transform: scale(1); }
+            50% { transform: scale(1.05); }
+            100% { transform: scale(1); }
+        }
+        
+        h1 {
+            color: #2c3e50;
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            font-weight: 600;
+        }
+        
+        .subtitle {
+            color: #7f8c8d;
+            font-size: 1.2rem;
+            margin-bottom: 2rem;
+            line-height: 1.6;
+        }
+        
+        .app-name {
+            color: #667eea;
+            font-weight: bold;
+        }
+        
+        .instruction {
+            background: #f8f9fa;
+            padding: 1.5rem;
+            border-radius: 12px;
+            margin: 2rem 0;
+            border-left: 4px solid #667eea;
+        }
+        
+        .instruction p {
+            color: #5a6c7d;
+            font-size: 1.1rem;
+            margin: 0;
+        }
+        
+        .close-button {
+            background: linear-gradient(45deg, #667eea, #764ba2);
+            color: white;
+            border: none;
+            padding: 1rem 2rem;
+            border-radius: 50px;
+            font-size: 1.1rem;
+            cursor: pointer;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            margin-top: 1rem;
+        }
+        
+        .close-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 20px rgba(102, 126, 234, 0.3);
+        }
+        
+        .footer {
+            margin-top: 2rem;
+            color: #95a5a6;
+            font-size: 0.9rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="success-icon"></div>
+        
+        <h1>認証完了！</h1>
+        
+        <p class="subtitle">
+            <span class="app-name">musicDL</span> の認証が正常に完了しました。<br>
+            お疲れさまでした！
+        </p>
+        
+        <div class="instruction">
+            <p>このタブを閉じて、アプリケーションに戻ってください。</p>
+        </div>
+        
+        <button class="close-button" onclick="window.close()">
+            このタブを閉じる
+        </button>
+        
+        <div class="footer">
+            musicDL - Music Download & Sharing Tool
+        </div>
+    </div>
+    
+    <script>
+        // 5秒後に自動的にタブを閉じる（オプション）
+        setTimeout(() => {
+            const shouldAutoClose = confirm('5秒が経過しました。このタブを自動的に閉じますか？');
+            if (shouldAutoClose) {
+                window.close();
+            }
+        }, 5000);
+    </script>
+</body>
+</html>

--- a/musicDL.csproj
+++ b/musicDL.csproj
@@ -6,6 +6,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishSingleFile>true</PublishSingleFile>
+    <AssemblyName>musicdl</AssemblyName>
+    <Authors>shuit</Authors>
+    <Company />
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,11 +18,14 @@
     <PackageReference Include="SpotifyAPI.Web" Version="7.2.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.ComponentModel.Composition" Version="9.0.6" />
-    <PackageReference Include="TagLibSharp" Version="2.3.0" />
+    <PackageReference Include="z440.atl.core" Version="7.3.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="setting.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="auth-success.html">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -36,6 +43,13 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Message.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
 


### PR DESCRIPTION
`AlbumArt.cs` で `TagLib` から `ATL` への依存関係を変更し、メタデータの取得と保存方法を更新しました。`AudioConverter.cs` ではメタデータのコピー処理を `ATL` に移行し、`CopyMetadataAsync` メソッドを静的にしました。`SharingMusic.cs` では認証成功時のレスポンス処理を改善し、HTMLファイルを読み込む新メソッド `LoadAuthSuccessHtml` を追加しました。新しい `auth-success.html` ファイルも追加され、スタイリッシュなデザインが施されました。`musicDL.csproj` では `TagLibSharp` の依存関係を削除し、`z440.atl.core` を追加しました。