### PR TITLE
feat: メタデータ取得をSpotify APIから自前のMusicBrainz APIへ移行

### DIFF
--- a/AlbumArt.cs
+++ b/AlbumArt.cs
@@ -1,157 +1,124 @@
-﻿using System.Text;
-using Newtonsoft.Json.Linq;
-using SpotifyAPI.Web;
-using System.Text.RegularExpressions;
+using musicDL.Models;
 using musicDL.Resources;
 using ATL;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 
 namespace musicDL
 {
     internal partial class AlbumArt
     {
-        public static async Task SelectMetadata(string artist, string title, string filePath, Dictionary<string, object> setting)
+        private const string CoverArtArchiveUrl = "https://coverartarchive.org/release/{0}/front";
+
+        public static async Task SelectMetadata(string artist, string title, string filePath,
+            Dictionary<string, object> setting, string accessToken)
         {
             var track = new Track(filePath);
 
-            string clientId = setting["spotifyClientId"].ToString() ??
-                throw new ArgumentNullException("spotifyClientId");
-            string clientSecret = setting["spotifyClientSecret"].ToString() ??
-                throw new ArgumentNullException("spotifyClientSecret");
-            string tokenUrl = setting["spotifyTokenUrl"]?.ToString() ??
-                throw new ArgumentNullException("spotifyTokenUrl");
-            HttpClient httpClient = new();
+            string metaEndpoint = setting["metaEndpoint"].ToString()?.TrimEnd('/')
+                ?? throw new ArgumentNullException("metaEndpoint");
 
-            // トークン取得用のHTTPリクエストを作成
-            HttpRequestMessage tokenRequest = new(HttpMethod.Post, tokenUrl);
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
-            // Authorizationヘッダーをセット
-            string authorizationHeader = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{clientId}:{clientSecret}"));
-            tokenRequest.Headers.Add("Authorization", $"Basic {authorizationHeader}");
+            // レコーディングを検索
+            var searchUrl = $"{metaEndpoint}/search?q={Uri.EscapeDataString(title)}&type=recording&limit=20";
+            var searchResponse = await httpClient.GetAsync(searchUrl);
+            if (!searchResponse.IsSuccessStatusCode)
+                throw new Exception($"メタデータ検索に失敗しました: {searchResponse.StatusCode}");
 
-            // POSTデータをセット
-            tokenRequest.Content = new FormUrlEncodedContent(new[]
+            var recordings = await searchResponse.Content.ReadFromJsonAsync<List<MbRecordingResult>>();
+
+            Console.WriteLine($@"{recordings?.Count ?? 0} items found");
+
+            MusicInfo? select;
+            if (recordings != null && recordings.Count != 0)
             {
-                new KeyValuePair<string, string>("grant_type", "client_credentials")
-            });
-
-            // トークンを取得
-            HttpResponseMessage tokenResponse = await httpClient.SendAsync(tokenRequest);
-            string tokenJson = await tokenResponse.Content.ReadAsStringAsync();
-
-            if (!tokenResponse.IsSuccessStatusCode)
-            {
-                throw new Exception($"Spotify API認証に失敗しました。Status: {tokenResponse.StatusCode}, Response: {tokenJson}");
-            }
-
-            var tokenData = JObject.Parse(tokenJson);
-            var tokenObj = tokenData["access_token"] ?? throw new Exception($"access_tokenの取得に失敗しました。Response: {tokenJson}");
-            string accessToken = tokenObj.ToString();
-            string query = $"track:\"{title}\" artist:\"{artist}\"";
-            var spotify = new SpotifyClient(accessToken);
-            var res = await spotify.Search.Item(new SearchRequest(SearchRequest.Types.Track, query))!;
-            //Console.WriteLine(JsonSerializer.Serialize(res.Tracks));
-            var items = res.Tracks.Items;
-            MusicInfo select;
-            Console.WriteLine($@"{items?.Count ?? 0} items found");
-            if (items != null && items.Count != 0)
-            {
-                select = SelectMusicInfo(items, spotify);
+                select = await SelectMusicInfo(recordings, httpClient, metaEndpoint);
+                if (select == null) return;
             }
             else
             {
                 Console.WriteLine(Message.noResultSearch);
-                Console.Write($@"{Message.enterTrackID} -> ");
-                string trackId = Console.ReadLine() ?? "";
-                if (string.IsNullOrEmpty(trackId)) // 入力が空の場合は終了
+                Console.Write($@"{Message.enterTrackID} (recording MBID) -> ");
+                string mbid = Console.ReadLine() ?? "";
+                if (string.IsNullOrEmpty(mbid))
                 {
                     Console.WriteLine(Message.trackIDInvalid);
                     return;
                 }
-                try
+                select = await GetMusicInfoFromRecording(mbid, httpClient, metaEndpoint);
+                if (select == null)
                 {
-                    var info = await spotify.Tracks.Get(trackId);
-                    // トラックIDから情報を正常に取得できた場合、MusicInfoオブジェクトを作成して返す
-                    select = new MusicInfo(info.Name, info.Artists.Select(x => x.Name).ToArray(),
-                        info.Album.Name, info.Album.Artists.Select(x => x.Name).ToArray(),
-                        new Uri(info.Album.Images[0].Url), info.Album.ReleaseDate, info.ExternalIds["isrc"],
-                        info.DiscNumber, info.TrackNumber,
-                        info.Album.TotalTracks);
-                }
-                catch (AggregateException ex)
-                {
-                    switch (ex.InnerException)
-                    {
-                        case APIException { Response.StatusCode: System.Net.HttpStatusCode.NotFound }:
-                            Console.ForegroundColor = ConsoleColor.Red;
-                            Console.WriteLine(Message.trackNotFound);
-                            Console.ResetColor();
-                            return;
-                        case APIException:
-                            // その他のAPI例外を処理 ex: IDの形式が不正
-                            Console.ForegroundColor = ConsoleColor.Red;
-                            Console.WriteLine(Message.trackIDInvalid);
-                            Console.ResetColor();
-                            return;
-                        default:
-                            throw;
-                    }
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine(Message.trackNotFound);
+                    Console.ResetColor();
+                    return;
                 }
             }
-            #region add album art
+
+            // アルバムアートを取得
             try
             {
-                string albumArt = select.AlbumArt.ToString();
-                string? dire = Directory.GetParent(AppContext.BaseDirectory)?.ToString();
-                string directlyPath = dire ?? $@"C:\Users\{Environment.UserName}";
-                if (!Directory.Exists($"{directlyPath}\\AlbumArt")) { Directory.CreateDirectory($"{directlyPath}\\AlbumArt"); }
-                string albumArtPath = "";
-                //urlの場合ダウンロードする
-                if (Regex.IsMatch(albumArt, @"https?://[\w!?/+\-_~;.,*&@#$%()'[\]]+"))
+                string dire = Directory.GetParent(AppContext.BaseDirectory)?.ToString()
+                              ?? $@"C:\Users\{Environment.UserName}";
+                if (!Directory.Exists($"{dire}\\AlbumArt"))
+                    Directory.CreateDirectory($"{dire}\\AlbumArt");
+
+                var coverUrl = string.Format(CoverArtArchiveUrl, select.ReleaseMbid);
+                using var coverClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = true });
+                var img = await coverClient.GetAsync(coverUrl);
+
+                if (img.IsSuccessStatusCode)
                 {
-                    var img = await httpClient.GetAsync(albumArt);
-                    var extension = img.Content.Headers.ContentType?.MediaType?.Split('/')[1];
-                    await using var st = await img.Content.ReadAsStreamAsync();
+                    var extension = img.Content.Headers.ContentType?.MediaType?.Split('/')[1] ?? "jpg";
                     string safeFileName = Path.GetFileName(filePath);
-                    albumArtPath = Path.Combine(directlyPath, "AlbumArt", $"{safeFileName}.{extension}");
-                    await using var file = new FileStream(albumArtPath, FileMode.OpenOrCreate, FileAccess.Write);
-                    await st.CopyToAsync(file);
-                    st.Close();
+                    string albumArtPath = Path.Combine(dire, "AlbumArt", $"{safeFileName}.{extension}");
+
+                    var imageBytes = await img.Content.ReadAsByteArrayAsync();
+                    await File.WriteAllBytesAsync(albumArtPath, imageBytes);
+
                     Console.WriteLine($@"Album Art on {albumArtPath}");
-                }
-                else if (File.Exists(albumArt))
-                {
-                    albumArtPath = albumArt;
+
+                    track.EmbeddedPictures.Clear();
+                    var albumArtInfo = PictureInfo.fromBinaryData(imageBytes);
+                    track.EmbeddedPictures.Add(albumArtInfo);
                 }
                 else
                 {
-                    Console.WriteLine(@"Album Art not found");
-                    return;
+                    Console.WriteLine($@"Album Art not found (Cover Art Archive: {img.StatusCode})");
                 }
-                //Apply Album Art
-                track.EmbeddedPictures.Clear();
-                var albumArtInfo = PictureInfo.fromBinaryData(File.ReadAllBytes(albumArtPath));
-                track.EmbeddedPictures.Add(albumArtInfo);
             }
             catch (Exception ex)
             {
                 Console.WriteLine($@"Album Art: {ex.Message}");
                 Console.WriteLine(ex);
             }
-            #endregion
 
-            //Add Metadata
+            // メタデータを設定
             try
             {
-                var release = DateTime.Parse(select.Release);
                 track.Title = select.Title;
                 track.Album = select.Album;
-                track.AlbumArtist = string.Join(' ', select.AlbumArtists);
-                track.Artist = string.Join(' ', select.Artists);
-                track.Year = release.Year;
-                track.OriginalReleaseDate = release;
-                track.DiscNumber = select.DiskNum;
-                track.TrackNumber = select.TrackNum;
-                track.ISRC = select.ISRC;
+                track.AlbumArtist = select.AlbumArtistCredit;
+                track.Artist = select.ArtistCredit;
+                track.DiscNumber = select.DiscNumber;
+                track.TrackNumber = select.TrackNumber;
+                track.TrackTotal = select.TrackCount;
+
+                if (!string.IsNullOrEmpty(select.ReleaseDate))
+                {
+                    if (DateTime.TryParse(select.ReleaseDate, out var releaseDate))
+                    {
+                        track.Year = releaseDate.Year;
+                        track.OriginalReleaseDate = releaseDate;
+                    }
+                    else if (int.TryParse(select.ReleaseDate, out var year))
+                    {
+                        track.Year = year;
+                    }
+                }
+
                 track.Save();
             }
             catch (Exception ex)
@@ -159,52 +126,34 @@ namespace musicDL
                 Console.WriteLine($@"Metadata: {ex.Message}");
                 Console.WriteLine(ex);
             }
-            return;
         }
 
-        private static MusicInfo SelectMusicInfo(List<FullTrack> items, SpotifyClient spotify)
+        private static async Task<MusicInfo?> SelectMusicInfo(List<MbRecordingResult> recordings,
+            HttpClient httpClient, string metaEndpoint)
         {
             int n = 0;
-            int num = 0;
-            List<MusicInfo> list = [];
             while (true)
             {
-                list.Clear();
-                int i;
-                for (i = n; i < n + 3; i++)
-                {
-                    if (i >= items?.Count) { break; }
-                    var title = items?[i].Name ?? throw new Exception();
-                    var album = items[i].Album.Name ?? throw new Exception();
-                    var albumArt = items[i].Album.Images?[0].Url ?? throw new Exception();
-                    var release = items[i].Album.ReleaseDate ?? throw new Exception();
-                    var isrc = items[i].ExternalIds["isrc"]?.ToString() ?? throw new Exception();
-                    var diskNum = items[i].DiscNumber;
-                    var trackNum = items[i].TrackNumber;
-                    var albumTrackNum = items[i].Album.TotalTracks;
-                    MusicInfo musicInfo = new(title, (from artist in items?[i]?.Artists ?? throw new Exception() select artist.Name ?? throw new Exception()).ToArray(), album, (from artist in items[i].Album.Artists ?? throw new Exception() select artist.Name ?? throw new Exception()).ToArray(), new Uri(albumArt),
-                        release, isrc, diskNum, trackNum, albumTrackNum);
-                    list.Add(musicInfo);
-                }
-                n += 3;
+                var page = recordings.Skip(n).Take(3).ToList();
+
                 int x = 1;
-                foreach (var item in list)
+                foreach (var item in page)
                 {
                     Console.WriteLine($@"{x}: {item.Title}");
-                    Console.WriteLine($@"artists: {string.Join(", ", item.Artists)}");
-                    Console.WriteLine($@"album: {item.Album}");
-                    Console.WriteLine($@"album artists: {string.Join(", ", item.AlbumArtists)}");
-                    Console.WriteLine($@"album art: {item.AlbumArt}");
-                    Console.WriteLine($@"release: {item.Release}");
+                    Console.WriteLine($@"   artist: {item.ArtistCredit}");
+                    if (item.LengthMs.HasValue)
+                        Console.WriteLine($@"   length: {TimeSpan.FromMilliseconds(item.LengthMs.Value):m\:ss}");
                     Console.WriteLine();
                     x++;
                 }
-                switch (list.Count)
+
+                n += 3;
+
+                switch (page.Count)
                 {
-                    // []は空文字時にマッチする ()はカッコ内の文字列でもマッチする
                     case 0:
                         Console.WriteLine(Message.noMoreItems);
-                        Console.WriteLine($@"{Message.selectTheNumber}: (b)ack -> ");
+                        Console.Write($@"{Message.selectTheNumber}: (b)ack -> ");
                         break;
                     case 1:
                         Console.Write($@"{Message.selectTheNumber}: [1] (b)ack -> ");
@@ -216,111 +165,151 @@ namespace musicDL
                         Console.Write($@"{Message.selectTheNumber}: [1] 2 3 (n)ext (b)ack -> ");
                         break;
                 }
-                string selectNum = Console.ReadLine() ?? "1";
-                if (string.IsNullOrEmpty(selectNum)) selectNum = "1";
-                if (selectNum is "next" or "n")
+
+                string input = Console.ReadLine() ?? "1";
+                if (string.IsNullOrEmpty(input)) input = "1";
+
+                if (input is "next" or "n")
                 {
-                    Console.Clear();
+                    if (n >= recordings.Count)
+                    {
+                        Console.ForegroundColor = ConsoleColor.Yellow;
+                        Console.WriteLine(Message.noMoreItems);
+                        Console.ResetColor();
+                        int rem = recordings.Count % 3;
+                        n = recordings.Count - (rem == 0 ? 3 : rem);
+                        if (n < 0) n = 0;
+                    }
+                    else
+                    {
+                        Console.Clear();
+                    }
                 }
-                else if (selectNum is "1" or "2" or "3")
-                {
-                    num = Convert.ToInt32(selectNum) - 1;
-                    break;
-                }
-                else if (selectNum is "back" or "b")
+                else if (input is "back" or "b")
                 {
                     Console.Clear();
                     n -= 6;
-                    if (n >= 0) continue;
-                    Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.WriteLine(Message.firstPage);
-                    Console.ResetColor();
-                    n = 0;
-                }
-                else
-                {
-                    n = 0;
-                    try
+                    if (n < 0)
                     {
-                        var info = spotify.Tracks.Get(selectNum).Result;
-                        // トラックIDから情報を正常に取得できた場合、MusicInfoオブジェクトを作成して返す
-                        MusicInfo musicInfo = new(info.Name, info.Artists.Select(x => x.Name).ToArray(),
-                            info.Album.Name, info.Album.Artists.Select(x => x.Name).ToArray(),
-                            new Uri(info.Album.Images[0].Url), info.Album.ReleaseDate,info.ExternalIds["isrc"],
-                            info.DiscNumber, info.TrackNumber,
-                            info.Album.TotalTracks);
-                        return musicInfo;
-
+                        Console.ForegroundColor = ConsoleColor.Yellow;
+                        Console.WriteLine(Message.firstPage);
+                        Console.ResetColor();
+                        n = 0;
                     }
-                    catch (AggregateException ex)
+                }
+                else if (int.TryParse(input, out int num) && num >= 1 && num <= page.Count)
+                {
+                    var selected = page[num - 1];
+                    return await GetMusicInfoFromRecording(selected.Mbid, httpClient, metaEndpoint);
+                }
+                else if (Guid.TryParse(input, out _))
+                {
+                    return await GetMusicInfoFromRecording(input, httpClient, metaEndpoint);
+                }
+            }
+        }
+
+        private static async Task<MusicInfo?> GetMusicInfoFromRecording(string recordingMbid,
+            HttpClient httpClient, string metaEndpoint)
+        {
+            var recUrl = $"{metaEndpoint}/recording/{Uri.EscapeDataString(recordingMbid)}";
+            var recResponse = await httpClient.GetAsync(recUrl);
+            if (!recResponse.IsSuccessStatusCode)
+            {
+                Console.WriteLine($"レコーディング取得失敗: {recResponse.StatusCode}");
+                return null;
+            }
+
+            var recording = await recResponse.Content.ReadFromJsonAsync<MbRecordingDetail>();
+            if (recording == null) return null;
+
+            // リリースを選択
+            MbReleaseRef? releaseRef = null;
+            if (recording.Releases == null || recording.Releases.Count == 0)
+            {
+                Console.WriteLine("このレコーディングに関連するリリースが見つかりません。");
+                return null;
+            }
+            else if (recording.Releases.Count == 1)
+            {
+                releaseRef = recording.Releases[0];
+            }
+            else
+            {
+                Console.WriteLine("リリースを選択してください:");
+                for (int i = 0; i < recording.Releases.Count; i++)
+                {
+                    var r = recording.Releases[i];
+                    Console.WriteLine($"{i + 1}: {r.Title} / {r.ArtistCredit} ({r.Date})");
+                }
+                Console.Write("番号を入力 [1]: ");
+                string sel = Console.ReadLine() ?? "1";
+                if (string.IsNullOrEmpty(sel)) sel = "1";
+                if (!int.TryParse(sel, out int idx) || idx < 1 || idx > recording.Releases.Count)
+                    idx = 1;
+                releaseRef = recording.Releases[idx - 1];
+            }
+
+            // リリース詳細を取得してディスク/トラック番号を特定
+            var relUrl = $"{metaEndpoint}/release/{Uri.EscapeDataString(releaseRef.Mbid)}";
+            var relResponse = await httpClient.GetAsync(relUrl);
+            if (!relResponse.IsSuccessStatusCode)
+            {
+                Console.WriteLine($"リリース取得失敗: {relResponse.StatusCode}");
+                return null;
+            }
+
+            var release = await relResponse.Content.ReadFromJsonAsync<MbReleaseDetail>();
+            if (release == null) return null;
+
+            // このレコーディングのディスク/トラック番号を探す
+            int discNumber = 1, trackNumber = 1, trackCount = 0;
+            string trackArtistCredit = recording.ArtistCredit;
+
+            foreach (var medium in release.Media ?? [])
+            {
+                foreach (var t in medium.Tracks ?? [])
+                {
+                    if (t.RecordingMbid == recording.Mbid)
                     {
-                        switch (ex.InnerException)
-                        {
-                            case APIException { Response.StatusCode: System.Net.HttpStatusCode.NotFound }:
-                                Console.Clear();
-                                Console.ForegroundColor = ConsoleColor.Red;
-                                Console.WriteLine(Message.trackNotFound);
-                                Console.ResetColor();
-                                continue;
-                            case APIException:
-                                // その他のAPI例外を処理 ex: IDの形式が不正
-                                Console.Clear();
-                                Console.ForegroundColor = ConsoleColor.Red;
-                                Console.WriteLine(Message.trackIDInvalid);
-                                Console.ResetColor();
-                                continue;
-                            default:
-                                throw;
-                        }
+                        discNumber = medium.DiscNumber;
+                        trackNumber = t.Position;
+                        trackCount = medium.TrackCount;
+                        if (!string.IsNullOrEmpty(t.ArtistCredit))
+                            trackArtistCredit = t.ArtistCredit;
+                        goto found;
                     }
                 }
             }
-            return list[num];
+            found:
+
+            return new MusicInfo
+            {
+                RecordingMbid = recording.Mbid,
+                Title = recording.Title,
+                ArtistCredit = trackArtistCredit,
+                Album = release.Title,
+                AlbumArtistCredit = release.ArtistCredit,
+                ReleaseMbid = release.Mbid,
+                ReleaseDate = release.Date,
+                DiscNumber = discNumber,
+                TrackNumber = trackNumber,
+                TrackCount = trackCount
+            };
         }
 
         private class MusicInfo
         {
-            public string Title { get; set; }
-            public string[] Artists { get; set; }
-            public string Album { get; set; }
-            public string[] AlbumArtists { get; set; }
-            public Uri AlbumArt { get; set; }
-            public string Release { get; set; }
-            public string ISRC { get; set; }
-            public int DiskNum { get; set; }
-            public int TrackNum { get; set; }
-            public int AlbumTrackNum { get; set; }
-
-
-            public MusicInfo(string title, string[] artists, string album,
-                string[] albumArtists, Uri albumArt, string release,
-                string isrc, int diskNum, int trackNum, int albumTrackNum)
-            {
-                Title = title;
-                Artists = artists;
-                Album = album;
-                AlbumArtists = albumArtists;
-                AlbumArt = albumArt;
-                Release = release;
-                ISRC = isrc;
-                DiskNum = diskNum;
-                TrackNum = trackNum;
-                AlbumTrackNum = albumTrackNum;
-            }
-
-            public MusicInfo()
-            {
-                Title = "";
-                Artists = [];
-                Album = "";
-                AlbumArtists = [];
-                AlbumArt = new Uri("https://example.com");
-                Release = "";
-                ISRC = "";
-                DiskNum = 0;
-                TrackNum = 0;
-                AlbumTrackNum = 0;
-            }
-            }
+            public string RecordingMbid { get; set; } = "";
+            public string Title { get; set; } = "";
+            public string ArtistCredit { get; set; } = "";
+            public string Album { get; set; } = "";
+            public string AlbumArtistCredit { get; set; } = "";
+            public string ReleaseMbid { get; set; } = "";
+            public string ReleaseDate { get; set; } = "";
+            public int DiscNumber { get; set; } = 1;
+            public int TrackNumber { get; set; } = 1;
+            public int TrackCount { get; set; } = 0;
+        }
     }
 }

--- a/MetadataProcessor.cs
+++ b/MetadataProcessor.cs
@@ -29,8 +29,9 @@ namespace musicDL
 
             try
             {
-                await AlbumArt.SelectMetadata(this.Artist, this.Title, filePath, setting["AlbumArt"]);
-                await SharingMusic.Shring(setting["Sharing"], filePath);
+                string accessToken = await SharingMusic.GetToken(setting["Sharing"]);
+                await AlbumArt.SelectMetadata(this.Artist, this.Title, filePath, setting["AlbumArt"], accessToken);
+                await SharingMusic.Shring(setting["Sharing"], filePath, accessToken);
 
                 Console.WriteLine(Message.metadataComplete);
 

--- a/Models/MbMeta.cs
+++ b/Models/MbMeta.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace musicDL.Models
+{
+    internal class MbRecordingResult
+    {
+        [JsonPropertyName("mbid")] public string Mbid { get; set; } = "";
+        [JsonPropertyName("title")] public string Title { get; set; } = "";
+        [JsonPropertyName("artist_credit")] public string ArtistCredit { get; set; } = "";
+        [JsonPropertyName("length_ms")] public int? LengthMs { get; set; }
+        [JsonPropertyName("comment")] public string? Comment { get; set; }
+    }
+
+    internal class MbRecordingDetail
+    {
+        [JsonPropertyName("mbid")] public string Mbid { get; set; } = "";
+        [JsonPropertyName("title")] public string Title { get; set; } = "";
+        [JsonPropertyName("artist_credit")] public string ArtistCredit { get; set; } = "";
+        [JsonPropertyName("length_ms")] public int? LengthMs { get; set; }
+        [JsonPropertyName("releases")] public List<MbReleaseRef>? Releases { get; set; }
+    }
+
+    internal class MbReleaseRef
+    {
+        [JsonPropertyName("mbid")] public string Mbid { get; set; } = "";
+        [JsonPropertyName("title")] public string Title { get; set; } = "";
+        [JsonPropertyName("artist_credit")] public string ArtistCredit { get; set; } = "";
+        [JsonPropertyName("date")] public string Date { get; set; } = "";
+    }
+
+    internal class MbReleaseDetail
+    {
+        [JsonPropertyName("mbid")] public string Mbid { get; set; } = "";
+        [JsonPropertyName("title")] public string Title { get; set; } = "";
+        [JsonPropertyName("artist_credit")] public string ArtistCredit { get; set; } = "";
+        [JsonPropertyName("date")] public string Date { get; set; } = "";
+        [JsonPropertyName("media")] public List<MbMedium>? Media { get; set; }
+    }
+
+    internal class MbMedium
+    {
+        [JsonPropertyName("disc_number")] public int DiscNumber { get; set; }
+        [JsonPropertyName("track_count")] public int TrackCount { get; set; }
+        [JsonPropertyName("tracks")] public List<MbTrack>? Tracks { get; set; }
+    }
+
+    internal class MbTrack
+    {
+        [JsonPropertyName("position")] public int Position { get; set; }
+        [JsonPropertyName("title")] public string Title { get; set; } = "";
+        [JsonPropertyName("artist_credit")] public string ArtistCredit { get; set; } = "";
+        [JsonPropertyName("recording_mbid")] public string RecordingMbid { get; set; } = "";
+    }
+}

--- a/SharingMusic.cs
+++ b/SharingMusic.cs
@@ -13,12 +13,12 @@ namespace musicDL
     {
         private const string RedirectUri = "http://localhost:8080/callback";
 
-        public static async Task Shring(Dictionary<string, object> setting, string filePath)
+        public static async Task Shring(Dictionary<string, object> setting, string filePath, string? accessToken = null)
         {
             try
             {
                 Console.WriteLine("Sharing files to your own device");
-                string accessToken = await GetToken(setting);
+                accessToken ??= await GetToken(setting);
                 using var client = new HttpClient();
                 string uploadUrl = setting["uploadEndpoint"].ToString() ?? "https://musicdl.shuit.net/api/upload";
                 MultipartFormDataContent content = [];
@@ -63,7 +63,7 @@ namespace musicDL
             }
         }
 
-        private static async Task<string> GetToken(Dictionary<string, object> setting)
+        internal static async Task<string> GetToken(Dictionary<string, object> setting)
         {
             if (string.IsNullOrEmpty(setting?["clientId"].ToString()))
                 throw new ArgumentException("clientId is not set in settings.");

--- a/musicDL.csproj
+++ b/musicDL.csproj
@@ -14,9 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SpotifyAPI.Web" Version="7.2.1" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.ComponentModel.Composition" Version="9.0.6" />
     <PackageReference Include="z440.atl.core" Version="7.3.0" />
   </ItemGroup>

--- a/setting.json
+++ b/setting.json
@@ -2,9 +2,7 @@
   "ffmpegPath": "ffmpeg",
   "extended": {
     "AlbumArt": {
-      "spotifyClientId": "adf15576cf904669bd245826f4f96b01",
-      "spotifyClientSecret": "b144f7c7e957479994dc850c31eb69e8",
-      "spotifyTokenUrl": "https://accounts.spotify.com/api/token"
+      "metaEndpoint": "https://musicdl.shuit.net/api/meta"
     },
     "Sharing": {
       "uploadEndpoint": "https://musicdl.shuit.net/api/upload?name=cli",


### PR DESCRIPTION
## 変更内容
- `AlbumArt.cs` を Spotify API から自前の MetaController API（MusicBrainz）へ全面書き換え
- アルバムアートの取得先を Spotify CDN から [Cover Art Archive](https://coverartarchive.org) へ変更
- `Models/MbMeta.cs` を新規作成し、MetaController APIレスポンスモデルを分離
- `SharingMusic.GetToken` を `internal static` に昇格し、トークンを AlbumArt と Shring で共有（ブラウザ認証が1回に削減）
- `SpotifyAPI.Web` / `Newtonsoft.Json` パッケージを削除
- `setting.json` の AlbumArt セクションを `metaEndpoint` のみに変更

## テスト手順
- [ ] `process` / `transform` コマンドでメタデータ取得が正常に動作すること
- [ ] 検索結果から曲を選択できること（next/back/番号入力/MBID直接入力）
- [ ] アルバムアートが Cover Art Archive から取得・埋め込まれること
- [ ] リリースが複数ある場合のリリース選択UIが動作すること
- [ ] ブラウザ認証が1回のみ表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)