### PR TITLE
楽曲選択時の UX 改善: MusicBrainz URL 表示・メタデータ取得中の進捗表示

### DIFF
--- a/AlbumArt.cs
+++ b/AlbumArt.cs
@@ -23,7 +23,11 @@ namespace musicDL
 
             // レコーディングを検索
             var searchUrl = $"{metaEndpoint}/search?q={Uri.EscapeDataString(title)}&type=recording&limit=20";
-            var searchResponse = await httpClient.GetAsync(searchUrl);
+            var searchTask = httpClient.GetAsync(searchUrl);
+            while (!searchTask.IsCompleted)
+                Spiner.Spin("Searching...");
+            Console.SetCursorPosition(0, Console.CursorTop);
+            var searchResponse = await searchTask;
             if (!searchResponse.IsSuccessStatusCode)
                 throw new Exception($"メタデータ検索に失敗しました: {searchResponse.StatusCode}");
 
@@ -67,7 +71,11 @@ namespace musicDL
 
                 var coverUrl = string.Format(CoverArtArchiveUrl, select.ReleaseMbid);
                 using var coverClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = true });
-                var img = await coverClient.GetAsync(coverUrl);
+                var coverTask = coverClient.GetAsync(coverUrl);
+                while (!coverTask.IsCompleted)
+                    Spiner.Spin("Fetching album art...");
+                Console.SetCursorPosition(0, Console.CursorTop);
+                var img = await coverTask;
 
                 if (img.IsSuccessStatusCode)
                 {
@@ -214,7 +222,11 @@ namespace musicDL
             HttpClient httpClient, string metaEndpoint)
         {
             var recUrl = $"{metaEndpoint}/recording/{Uri.EscapeDataString(recordingMbid)}";
-            var recResponse = await httpClient.GetAsync(recUrl);
+            var recTask = httpClient.GetAsync(recUrl);
+            while (!recTask.IsCompleted)
+                Spiner.Spin("Fetching metadata...");
+            Console.SetCursorPosition(0, Console.CursorTop);
+            var recResponse = await recTask;
             if (!recResponse.IsSuccessStatusCode)
             {
                 Console.WriteLine($"レコーディング取得失敗: {recResponse.StatusCode}");
@@ -253,7 +265,11 @@ namespace musicDL
 
             // リリース詳細を取得してディスク/トラック番号を特定
             var relUrl = $"{metaEndpoint}/release/{Uri.EscapeDataString(releaseRef.Mbid)}";
-            var relResponse = await httpClient.GetAsync(relUrl);
+            var relTask = httpClient.GetAsync(relUrl);
+            while (!relTask.IsCompleted)
+                Spiner.Spin("Fetching metadata...");
+            Console.SetCursorPosition(0, Console.CursorTop);
+            var relResponse = await relTask;
             if (!relResponse.IsSuccessStatusCode)
             {
                 Console.WriteLine($"リリース取得失敗: {relResponse.StatusCode}");


### PR DESCRIPTION
## Summary

- 楽曲選択一覧に MusicBrainz の URL を表示し、選択前に正しいトラックか確認できるようにした
- メタデータ取得中の HTTP リクエストにスピナーを追加し、適切な進捗テキストを表示するよう変更
  - レコーディング検索中: `Searching...`
  - レコーディング / リリース詳細取得中: `Fetching metadata...`
  - アルバムアート取得中: `Fetching album art...`
  - アップロード中の `Uploading...` は変更なし

## Test plan

- [ ] `process` コマンドで楽曲一覧に URL が表示されることを確認
- [ ] 各 HTTP リクエスト時に適切なスピナーが表示されることを確認
- [ ] アップロード時は `Uploading...` のまま表示されることを確認

https://claude.ai/code/session_01MaGC3KAJw3mahD41Cdtphe